### PR TITLE
Fix tests by making key an object and revert previous fix

### DIFF
--- a/can-single-reference-test.js
+++ b/can-single-reference-test.js
@@ -7,8 +7,9 @@ QUnit.module("can-single-reference");
 
 QUnit.test("basics", function(assert){
   var obj = {};
-  singleReference.set(obj, 'pet', 'dog');
-  var retrieved = singleReference.getAndDelete(obj, 'pet');
+  var pet = {};
+  singleReference.set(obj, pet, 'dog');
+  var retrieved = singleReference.getAndDelete(obj, pet);
   assert.equal(retrieved, 'dog', 'sets and retrieves successfully');
   assert.equal(Object.keys(obj).length, 0, 'also deletes when retrieved');
 });

--- a/can-single-reference.js
+++ b/can-single-reference.js
@@ -3,8 +3,8 @@ var CID = require("can-cid");
 
 var singleReference;
 
-function getKeyName(obj, key, extraKey) {
-	var keyName = extraKey ? CID(obj, key) + ":" + extraKey : CID(obj, key);
+function getKeyName(key, extraKey) {
+	var keyName = extraKey ? CID(key) + ":" + extraKey : CID(key);
 	return keyName || key;
 }
 
@@ -26,20 +26,19 @@ function getKeyName(obj, key, extraKey) {
 	};
 } else {*/
 singleReference = {
-    // obj is a function ... we need to place `value` on it so we can retreive it
-    // we can't use a global map
-    set: function(obj, key, value, extraKey){
-        // check if it has a single reference map
-        obj[getKeyName(obj, key, extraKey)] = value;
-    },
+	// obj is a function ... we need to place `value` on it so we can retreive it
+	// we can't use a global map
+	set: function(obj, key, value, extraKey){
+		// check if it has a single reference map
+		obj[getKeyName(key, extraKey)] = value;
+	},
 
-    getAndDelete: function(obj, key, extraKey){
-        var keyName = getKeyName(obj, key, extraKey);
-        var value = obj[keyName];
+	getAndDelete: function(obj, key, extraKey){
+		var keyName = getKeyName(key, extraKey);
+		var value = obj[keyName];
 		delete obj[keyName];
-		delete obj._cid;
-        return value;
-    }
+		return value;
+	}
 };
 /*}*/
 


### PR DESCRIPTION
Reverts Cherif's previous changes to get this passing. They introduced an issue by deleting `obj._cid` and changed behavior in general.

All that was needed to get this test passing was to pass an object rather than a string. can-cid must be passed an object or function. Due to the inclusion of `use strict` in can-cid primitives can no longer have a cid.

Alternatively, instead of changing this test we could remove `use strict` from can-cid. It may be more correct since can-cid might as well be able to take primitives imo.

Fixes https://github.com/canjs/can-single-reference/issues/6.

